### PR TITLE
Fixed problem with "click" LED lighting up whenever the "up" LED is lit.

### DIFF
--- a/firmware/Arduino/makey_makey/makey_makey.ino
+++ b/firmware/Arduino/makey_makey/makey_makey.ino
@@ -531,7 +531,7 @@ void cycleLEDs() {
 
   if ((ledCycleCounter == 0) && inputs[0].pressed) {
     pinMode(inputLED_a, INPUT);
-    digitalWrite(inputLED_a, HIGH);
+    digitalWrite(inputLED_a, LOW);
     pinMode(inputLED_b, OUTPUT);
     digitalWrite(inputLED_b, HIGH);
     pinMode(inputLED_c, OUTPUT);
@@ -594,7 +594,7 @@ void danceLeds()
   {
     // UP
     pinMode(inputLED_a, INPUT);
-    digitalWrite(inputLED_a, HIGH);
+    digitalWrite(inputLED_a, LOW);
     pinMode(inputLED_b, OUTPUT);
     digitalWrite(inputLED_b, HIGH);
     pinMode(inputLED_c, OUTPUT);


### PR DESCRIPTION
Hi,
I noticed that when the LED for "up" is lit, it also (dimly) lights the "click" LED. This change fixes that.
I just want to say that I'm a huge fan of this project, and am happy to help improve/extend it in any way possible :)
